### PR TITLE
Gjør Docker bilde distroless

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Oppsett for prosjektet
+.env
+.github/
+.gitignore
+.nais/
+.pre-commit-config.yaml
+Dockerfile
+bob.svg
+justfile
+ruff.toml
+tests/
+
+# Cache mapper
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Virtueltmiljø
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
 # Vi bruker et Docker image fra uv hvor uv allerede er installert
-FROM ghcr.io/astral-sh/uv:0.4.8-python3.12-bookworm-slim
-# Opprett arbeidsmappe for prosjektet i Docker
-WORKDIR /nks_slackbob
+FROM ghcr.io/astral-sh/uv:0.4.12-bookworm-slim AS builder
 # Be uv kompilere kilder for raskere oppstart
 ENV UV_COMPILE_BYTECODE=1
+# Kopier fra cache siden vi bruker --mount
+ENV UV_LINK_MODE=copy
+# Installer Python i samme mappe som applikasjonen
+ENV UV_PYTHON_INSTALL_DIR=/app/
+# Opprett arbeidsmappe for prosjektet i Docker
+WORKDIR /app
+# Installer avhengigheter for prosjektet uten koden
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev
 # Kopier kode inn i Docker bildet
-COPY README.md .
-COPY pyproject.toml .
-COPY uv.lock .
-# Installer bare avhengigheter (bruker uv.lock)
-RUN uv sync --frozen --no-install-project
-# Kopier inn kildekode som vi forventer endrer seg
-COPY src src
-# Installer prosjektet ved hjelp av 'uv.lock'
-RUN uv sync --frozen
-# Eksponer virtual environment fra installasjonen
-ENV PATH="/nks_slackbob/.venv/bin:$PATH"
-# Tomt entry point for å ikke kjøre uv
-ENTRYPOINT [ ]
+ADD . /app
+# Installer prosjektet
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# Bildet vi ender opp med blir distroless
+FROM gcr.io/distroless/base-debian12
+# Kopier kode fra byggebildet
+COPY --from=builder --chown=app:app /app /app
+# Eksponer pakker fra virtueltmiljø
+ENV PATH="/app/.venv/bin:$PATH"
 # Server applikasjonen som default for Docker bildet
-CMD ["nks-slackbob"]
+CMD ["python3", "/app/src/nks_slackbob/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,5 @@ COPY --from=builder --chown=python:python /python /python
 COPY --from=builder --chown=app:app /app /app
 # Eksponer pakker fra virtueltmiljø
 ENV PATH="/app/.venv/bin:$PATH"
-# Fjern inngang for å ikke automatisk kjøre CMD med Python
-ENTRYPOINT [ ]
 # Server applikasjonen som default for Docker bildet
 CMD ["nks-slackbob"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nks-slackbob"
 version = "0.1.0"
 description = "Slackbot for NKS Kunnskapsbase Basert Språkmodell"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12, <3.13"
 dependencies = [
     "pydantic>=2.8.2",
     "pydantic-settings>=2.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,7 @@
 version = 1
-requires-python = ">=3.12"
+requires-python = "==3.12.*"
 resolution-markers = [
-    "python_full_version < '3.13'",
-    "python_full_version >= '3.13'",
+    "python_version < '0'",
 ]
 
 [[package]]


### PR DESCRIPTION
Dette reduserer antall sårbarheter ved at docker bilde rett og slett ikke inneholder en full Linux distro. Ved å fjerne alle unødvendige pakker er det mindre sannsynlig at det oppstår sårbarheter i applikasjoner utenfor vår egen.