### PR TITLE
Formater svar med Slack Block-er

### DIFF
--- a/src/nks_slackbob/blocks.py
+++ b/src/nks_slackbob/blocks.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 
-def message_block(msg: dict[str, Any]) -> list[dict[str, Any]]:
+def message_blocks(msg: dict[str, Any]) -> list[dict[str, Any]]:
     """Formater et svar fra KBS med Slack Block-er."""
     blocks: list[dict[str, Any]] = []
     blocks.append(answer_block(msg))

--- a/src/nks_slackbob/blocks.py
+++ b/src/nks_slackbob/blocks.py
@@ -7,9 +7,9 @@ def message_blocks(msg: dict[str, Any]) -> list[dict[str, Any]]:
     """Formater et svar fra KBS med Slack Block-er."""
     blocks: list[dict[str, Any]] = []
     blocks.append(answer_block(msg))
-    citations = context_block(msg)
-    if citations["elements"]:
-        blocks.append(citations)
+    context = context_block(msg)
+    if context["elements"]:
+        blocks.append(context)
     return blocks
 
 

--- a/src/nks_slackbob/blocks.py
+++ b/src/nks_slackbob/blocks.py
@@ -1,0 +1,50 @@
+"""Formatering for Slack Block-er."""
+
+from typing import Any
+
+
+def message_block(msg: dict[str, Any]) -> list[dict[str, Any]]:
+    """Formater et svar fra KBS med Slack Block-er."""
+    blocks: list[dict[str, Any]] = []
+    blocks.append(answer_block(msg))
+    citations = context_block(msg)
+    if citations["elements"]:
+        blocks.append(citations)
+    return blocks
+
+
+def answer_block(msg: dict[str, Any]) -> dict[str, Any]:
+    """Formater selve svaret fra KBS som en Slack Block."""
+    return {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": msg["answer"]["text"]},
+    }
+
+
+def context_block(msg: dict[str, Any]) -> dict[str, Any]:
+    """Formater siteringer som Slack Block."""
+    context_map = {ctx["metadata"]["KnowledgeArticleId"]: ctx for ctx in msg["context"]}
+    return {
+        "type": "context",
+        "elements": [
+            cite_block(cite, context_map[cite["article"]])
+            # MERK: Det er maksimalt lov med 10 elementer i en 'context' block
+            # vi kutter derfor antall siteringer hvis det er flere, noe som
+            # veldig sjeldent forekommer
+            for cite in msg["answer"]["citations"][:10]
+        ],
+    }
+
+
+def cite_block(citation: dict[str, str], doc: dict[str, Any]) -> dict[str, Any]:
+    """Formater en enkelt sitering som en Slack Block."""
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": (
+                f"*<{doc['metadata']['KnowledgeArticle_QuartoUrl']}|{citation['title']}>*"
+                f"\n_{citation['text']}_"
+            ),
+        },
+    }

--- a/src/nks_slackbob/main.py
+++ b/src/nks_slackbob/main.py
@@ -14,9 +14,10 @@ from slack_sdk import WebClient
 
 from . import settings
 from .auth import OAuth2Flow
+from .blocks import message_block
 from .expressions import WORKING_ON_ANSWER
 from .logging import setup_logging
-from .utils import USERNAME_PATTERN, convert_msg, format_slack, is_bob_alive, strip_msg
+from .utils import USERNAME_PATTERN, convert_msg, is_bob_alive, strip_msg
 
 API_URL = httpx.URL(str(settings.kbs_endpoint))
 """API URL til KBS systemet"""
@@ -65,7 +66,7 @@ def chat(client: WebClient, event: dict[str, str]) -> None:
     )
     # Sjekk tidlig om API-et kjører, slik at bruker slipper å vente
     if not is_bob_alive(API_URL):
-        log.info("'/is_alive' svarte ikke på KBS")
+        log.info("'/is_alive' endepunktet til KBS-en svarte ikke")
         update_msg(text="Kunnskapsbasen kjører ikke akkurat nå :construction:")
         return
     # Hent ut chat historikk og spørsmål fra brukeren
@@ -107,7 +108,7 @@ def chat(client: WebClient, event: dict[str, str]) -> None:
                         and now - last_update >= settings.update_rate_limit
                     ):
                         last_update = now
-                        update_msg(text=format_slack(reply))
+                        update_msg(blocks=message_block(reply))
     except httpx.ReadTimeout:
         log.error(
             "Spørring mot kunnskapbasen tok for lang tid",
@@ -123,7 +124,7 @@ def chat(client: WebClient, event: dict[str, str]) -> None:
         return
     log.info("Svarer bruker fra KBS")
     # Hent respons fra KBS og formater det for Slack
-    update_msg(text=format_slack(reply))
+    update_msg(blocks=message_block(reply))
 
 
 @app.event("app_mention")

--- a/src/nks_slackbob/main.py
+++ b/src/nks_slackbob/main.py
@@ -14,7 +14,7 @@ from slack_sdk import WebClient
 
 from . import settings
 from .auth import OAuth2Flow
-from .blocks import message_block
+from .blocks import message_blocks
 from .expressions import WORKING_ON_ANSWER
 from .logging import setup_logging
 from .utils import USERNAME_PATTERN, convert_msg, is_bob_alive, strip_msg
@@ -108,7 +108,7 @@ def chat(client: WebClient, event: dict[str, str]) -> None:
                         and now - last_update >= settings.update_rate_limit
                     ):
                         last_update = now
-                        update_msg(blocks=message_block(reply))
+                        update_msg(blocks=message_blocks(reply))
     except httpx.ReadTimeout:
         log.error(
             "Spørring mot kunnskapbasen tok for lang tid",
@@ -124,7 +124,7 @@ def chat(client: WebClient, event: dict[str, str]) -> None:
         return
     log.info("Svarer bruker fra KBS")
     # Hent respons fra KBS og formater det for Slack
-    update_msg(blocks=message_block(reply))
+    update_msg(blocks=message_blocks(reply))
 
 
 @app.event("app_mention")

--- a/src/nks_slackbob/utils.py
+++ b/src/nks_slackbob/utils.py
@@ -33,33 +33,16 @@ def strip_msg(msg: str) -> str:
     return msg.strip()
 
 
-def convert_msg(slack_msg: dict[str, str]) -> dict[str, str]:
+def convert_msg(slack_msg: dict[str, Any]) -> dict[str, str]:
     """Hjelpemetode som tar inn en Slack melding og konverterer til NKS KBS format."""
     result: dict[str, str] = {}
-    result["role"] = "ai" if "app_id" in slack_msg else "human"
-    text = strip_msg(slack_msg["text"])
-    result["content"] = text
+    if "app_id" in slack_msg:
+        result["role"] = "ai"
+        result["content"] = slack_msg["blocks"][0]["text"]["text"]
+    else:
+        result["role"] = "human"
+        result["content"] = strip_msg(slack_msg["text"])
     return result
-
-
-def format_slack(data: dict[str, Any]) -> str:
-    """Formater en melding fra KBS til en streng som kan brukes på Slack."""
-    text: str = data["answer"]["text"]
-    context_map = {
-        ctx["metadata"]["KnowledgeArticleId"]: ctx for ctx in data["context"]
-    }
-    cites = "\n\n".join(
-        [
-            f"> {cite['text'].replace('\n', ' ')}\n"
-            f"(_<{context_map[cite['article']]['metadata']['KnowledgeArticle_QuartoUrl']}|"
-            f"{cite['title'] or 'Uten tittel'} / "
-            f"{cite['section'] or 'Uten seksjon'}>_)"
-            for cite in data["answer"]["citations"]
-        ]
-    )
-    if cites:
-        text += f"\n{cites}"
-    return text
 
 
 def is_bob_alive(url: httpx.URL) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from nks_slackbob.utils import format_slack, strip_msg
+from nks_slackbob.utils import strip_msg
 
 
 @pytest.fixture
@@ -59,49 +59,6 @@ def answer_cites(context: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "context": context,
     }
-
-
-def test_format_no_cite(answer_no_cites: dict[str, Any]) -> None:
-    """Sjekk at KBS melding uten sitering formateres riktig."""
-    formatted = format_slack(answer_no_cites)
-    assert formatted == answer_no_cites["answer"]["text"]
-
-
-def test_format_cite(answer_cites: dict[str, Any]) -> None:
-    """Sjekk at KBS melding med sitering formateres riktig."""
-    formatted = format_slack(answer_cites)
-    assert formatted.startswith(answer_cites["answer"]["text"])
-    assert ">" in formatted
-    assert "https://localhost/id1" in formatted
-
-
-def test_strip_no_cite(answer_no_cites: dict[str, Any]) -> None:
-    """Sjekk at å fjerne Slack formatering fungerer som forventet."""
-    formatted = format_slack(answer_no_cites)
-    stripped = strip_msg(formatted)
-    assert stripped == answer_no_cites["answer"]["text"]
-
-
-def test_strip_cite(answer_cites: dict[str, Any]) -> None:
-    """Sjekk at å fjerne Slack formatering fungerer som forventet."""
-    formatted = format_slack(answer_cites)
-    stripped = strip_msg(formatted)
-    assert stripped == answer_cites["answer"]["text"]
-
-
-def test_strip_cite2(answer_cites: dict[str, Any]) -> None:
-    """Sjekk at 'strip_msg' klarer å fjerne flere sitater."""
-    answer_cites["answer"]["citations"].append(
-        {
-            "text": "Helt med mening!",
-            "article": "id2",
-            "title": "Sykepenger",
-            "section": "Til bruker",
-        }
-    )
-    formatted = format_slack(answer_cites)
-    stripped = strip_msg(formatted)
-    assert stripped == answer_cites["answer"]["text"]
 
 
 def test_strip_mention() -> None:


### PR DESCRIPTION
Dette gjør det enklere å style svaret fra Bob. Samtidig som det gjør det enklere å hente ut tekst fordi vi ikke trenger å fjerne siteringer eller lignende.